### PR TITLE
针对 Pomelo.as 内 onData 事件对 _pkg 清理时机不当的问题，做了少量调整

### DIFF
--- a/src/org/idream/pomelo/Pomelo.as
+++ b/src/org/idream/pomelo/Pomelo.as
@@ -12,16 +12,16 @@ package org.idream.pomelo
 	import flash.utils.Dictionary;
 	import flash.utils.clearTimeout;
 	import flash.utils.setTimeout;
-	
+
 	import org.idream.pomelo.interfaces.IMessage;
 	import org.idream.pomelo.interfaces.IPackage;
-	
+
 	[Event(name="handshake", type="org.idream.pomelo.PomeloEvent")]
 	[Event(name="kicked", type = "org.idream.pomelo.PomeloEvent")]
 	[Event(name="close", type = "flash.events.Event")]
 	[Event(name="ioError", type="flash.events.IOErrorEvent")]
 	[Event(name="securityError", type="flash.events.SecurityErrorEvent")]
-	
+
 	/**
 	 * Pomelo - Flash - TCP
 	 * @author Deo
@@ -31,37 +31,37 @@ package org.idream.pomelo
 	{
 		public static const requests:Dictionary = new Dictionary(true);
 		public static const info:Object = { sys: { version:"0.1.6b", type:"pomelo-flash-tcp", pomelo_version:"0.7.x" } };
-		
+
 		private var _handshake:Function;
 		private var _socket:Socket;
 		private var _hb:uint;
-		
+
 		private var _package:IPackage;
 		private var _message:IMessage;
-		
+
 		private var _pkg:Object;
-		
+
 		private var _useWeakReference:Boolean;
 		private var _routesAndCallbacks:Array = new Array();
-		
+
 		private static var _pomelo:Pomelo;
-		
+
 		public static function getIns():Pomelo
 		{
 			return _pomelo ||= new Pomelo(false);
 		}
-		
+
 		public var heartbeat:int;
-		
+
 		public function Pomelo(useWeakReference:Boolean = true)
 		{
 			_package = new Package();
 			_message = new Message();
 			_useWeakReference = useWeakReference;
-			
+
 			trace("[Pomelo] start:", JSON.stringify(info));
 		}
-		
+
 		/**
 		 * 初始化客户端，并尝试连接服务器
 		 * @param host
@@ -74,12 +74,12 @@ package org.idream.pomelo
 		public function init(host:String, port:int, user:Object = null, callback:Function = null, timeout:int = 8000, cross:int = 3843):void
 		{
 			info.user = user;
-			
+
 			_handshake = callback;
-			
+
 //			trace("[Pomelo] load policy file:", "xmlsocket://" + host + ":3843");
 			Security.loadPolicyFile("xmlsocket://" + host + ":" + cross);
-			
+
 			if (!_socket)
 			{
 				_socket = new Socket();
@@ -91,11 +91,11 @@ package org.idream.pomelo
 				_socket.addEventListener(IOErrorEvent.IO_ERROR, onIOError, false, 0, _useWeakReference);
 				_socket.addEventListener(SecurityErrorEvent.SECURITY_ERROR, onSecurityError, false, 0, _useWeakReference);
 			}
-			
+
 			trace("[Pomelo] start to connect server ...");
 			_socket.connect(host, port);
 		}
-		
+
 		/**
 		 * 与服务器主动断开连接
 		 */
@@ -105,29 +105,29 @@ package org.idream.pomelo
 			if (_socket && _socket.connected) _socket.close();
 			if (_hb) clearTimeout(_hb);
 		}
-		
+
 		/**
 		 * 向服务器请求数据
-		 * @param route
+		 * @param r5ute
 		 * @param msg
 		 * @param callback 服务器返回数据时会回调
 		 */
 		public function request(route:String, msg:Object, callback:Function = null):void
 		{
 			if (!route || !route.length) return;
-			
-			if (callback == null) 
+
+			if (callback == null)
 			{
 				this.notify(route, msg);
 				return;
 			}
-			
+
 			var req:Request = new Request(route, callback);
 			requests[req.id] = req;
-			
+
 			send(req.id, req.route, msg || {});
 		}
-		
+
 		/**
 		 * 向服务器发送数据
 		 * @param route
@@ -137,7 +137,7 @@ package org.idream.pomelo
 		{
 			send(0, route, msg || {});
 		}
-		
+
 		/**
 		 * 响应服务器的推送事件
 		 * @param route 推送事件的名称
@@ -148,7 +148,7 @@ package org.idream.pomelo
 			this.addEventListener(route, callback, false, 0, _useWeakReference);
 			_routesAndCallbacks.push([route, callback]);
 		}
-		
+
 		/**
 		 * 向服务器发送一次心跳事件
 		 */
@@ -156,65 +156,65 @@ package org.idream.pomelo
 		{
 			clearTimeout(_hb);
 			_hb = 0;
-			
+
 			if (_socket && _socket.connected)
 			{
 				_socket.writeBytes(_package.encode(Package.TYPE_HEARTBEAT));
 				_socket.flush();
 			}
 		}
-		
+
 		private function send(reqId:int, route:String, msg:Object):void
 		{
 			trace("[Pomelo] send msg: ", JSON.stringify(msg));
-			
+
 			var byte:ByteArray;
-			
+
 			byte = _message.encode(reqId, route, msg);
 			byte = _package.encode(Package.TYPE_DATA, byte);
-			
+
 			if (_socket && _socket.connected)
 			{
 				_socket.writeBytes(byte);
 				_socket.flush();
 			}
 		}
-		
+
 		private function onConnect(e:Event):void
 		{
 			trace("[Pomelo] connect success ...");
 			_socket.writeBytes(_package.encode(Package.TYPE_HANDSHAKE, Protocol.strencode(JSON.stringify(info))));
 			_socket.flush();
 		}
-		
+
 		private function onOutputProgress(e:OutputProgressEvent):void
 		{
 			trace("[Pomelo] flush ...");
 		}
-		
+
 		private function onClose(e:Event):void
 		{
 			trace("[Pomelo] connect close ...");
 			this.dispatchEvent(e);
 		}
-		
+
 		private function onIOError(e:IOErrorEvent):void
 		{
 			trace("[Pomelo] ", e);
 			this.dispatchEvent(e);
 		}
-		
+
 		private function onSecurityError(e:SecurityErrorEvent):void
 		{
 			trace("[Pomelo] ", e);
 			this.dispatchEvent(e);
 		}
-		
+
 		private function onData(e:ProgressEvent):void
 		{
 			trace("[Pomelo] client received:", _socket.bytesAvailable);
-			
-			do
+
+			while (_socket.bytesAvailable)
 			{
 				if (_pkg)
 				{
@@ -223,15 +223,19 @@ package org.idream.pomelo
 						_pkg.body = new ByteArray();
 						if (_pkg.length) _socket.readBytes(_pkg.body, 0, _pkg.length);
 					}
+          else
+          {
+            break;
+          }
 				}
-				else
+				else if (_socket.bytesAvailable >= 4)
 				{
 					_pkg = _package.decode(_socket);
 				}
-				
+
 				trace("[Package] type:", _pkg.type, "length:", _pkg.length);
-				
-				if (_pkg.body)
+
+				if (_pkg && _pkg.body)
 				{
 					switch(_pkg.type)
 					{
@@ -244,51 +248,51 @@ package org.idream.pomelo
 							_pkg = null;
 
 							trace("[Handshake] message:", message);
-							
+
 							var response:Object = JSON.parse(message);
-							
+
 							if (response.code == 200)
 							{
-								if (response.sys) 
+								if (response.sys)
 								{
 									Routedic.init(response.sys.dict);
 									Protobuf.init(response.sys.protos);
-									
+
 									this.heartbeat = response.sys.heartbeat;
 								}
-								
+
 								_socket.writeBytes(_package.encode(Package.TYPE_HANDSHAKE_ACK));
 								_socket.flush();
-								
+
 								this.dispatchEvent(new PomeloEvent(PomeloEvent.HANDSHAKE));
 							}
-							
+
 							if (_handshake != null) _handshake.call(this, response);
-							
+
 							break;
-						
+
 						case Package.TYPE_HANDSHAKE_ACK:
-							
+
 							_pkg.body.clear();
 							delete _pkg.body;
 							delete _pkg.type;
 							_pkg = null;
 
 							break;
-						
+
 						case Package.TYPE_HEARTBEAT:
-							
+
 							_pkg.body.clear();
 							delete _pkg.body;
 							delete _pkg.type;
 							_pkg = null;
-							
+
 							if (this.heartbeat)
 							{
 								_hb = setTimeout(beat, this.heartbeat * 1000);
 							}
 							break;
-						
+
 						case Package.TYPE_DATA:
 							var msg:Object = _message.decode(_pkg.body);
 
@@ -296,9 +300,9 @@ package org.idream.pomelo
 							delete _pkg.body;
 							delete _pkg.type;
 							_pkg = null;
-							
+
 							trace("[Message] route:", msg.route, "body:", JSON.stringify(msg.body));
-							
+
 							if (!msg.id)
 							{
 								this.dispatchEvent(new PomeloEvent(msg.route, msg.body));
@@ -308,9 +312,9 @@ package org.idream.pomelo
 								requests[msg.id].callback.call(this, msg.body);
 								requests[msg.id] = null;
 							}
-							
+
 							break;
-						
+
 						case Package.TYPE_KICK:
 
 							_pkg.body.clear();
@@ -319,14 +323,13 @@ package org.idream.pomelo
 							_pkg = null;
 
 							this.dispatchEvent(new PomeloEvent(PomeloEvent.KICKED));
-							
+
 							break;
 					}
 				}
-				
+
 				trace("[Pomelo] client next:", _socket.bytesAvailable);
 			}
-			while (!_pkg && _socket.bytesAvailable > 4);
 		}
 
 		public function get message():IMessage
@@ -338,7 +341,7 @@ package org.idream.pomelo
 		{
 			_message = value;
 		}
-		
+
 		/**
 		* if you use new Pomelo(false)
 		* (not using weak reference)
@@ -350,7 +353,7 @@ package org.idream.pomelo
 			{
 				this.removeEventListener(_routesAndCallbacks[r][0], _routesAndCallbacks[r][1]);
 			}
-			
+
 			_socket.removeEventListener(Event.CONNECT, onConnect);
 			_socket.removeEventListener(Event.CLOSE, onClose);
 			_socket.removeEventListener(OutputProgressEvent.OUTPUT_PROGRESS, onOutputProgress);


### PR DESCRIPTION
在 Pomelo.as 内，经处理获取 _pkg.body 后，会进入 swith (_pkg.type) 进行各种判断和处理。但 _pkg = null 的时机，有几个在 dispatchEvent 及 callback.call 之后。

如果外界的事件处理或回调处理过程中出现错误，则在 dispatchEvent 或 callback.call 之后的代码都不会被执行，包括 _pkg = null。

所以我将 _pkg 的清理时机提前，在用完它之后马上清除；并将清除代码多写了几行，以策内存安全。
